### PR TITLE
Auto-start sampler if not started

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,9 @@ internals.Policy.prototype.check = function () {
         return null;
     }
 
-    Hoek.assert(this._process._eventLoopTimer, 'Cannot check load when sampler is not started');
+    if (!this._process._eventLoopTimer) {
+        this.start();
+    }
 
     var elapsed = this._process._loadBench.elapsed();
     var load = this._process.load;


### PR DESCRIPTION
I keep running into this assertion `Cannot check load when sampler is not started` when running unit tests injected into the server. I used to be able to fix it by accessing the private heavy variable like:
```
if (!module.parent) { // This prevents server from starting during unit tests
    server.start(function(err) {
        if (err) {
            console.log(err);
        }
    });
} else {
    server._heavy.start();
}
```
But recently this stopped working, is there some reason that prevents instead of asserting it has started, just start it?