### PR TITLE
Add event loop utilization support

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,6 +9,7 @@ Creates a new heavy instance where:
   - `maxHeapUsedBytes` - maximum V8 heap size bytes. Defaults to `0` (no limit).
   - `maxRssBytes` - maximum process RSS size bytes. Defaults to `0` (no limit).
   - `maxEventLoopDelay` - maximum event loop delay duration in milliseconds. Defaults to `0` (no limit).
+  - `maxEventLoopUtilization` - maximum event loop utilization value. Defaults to `0` (no limit).
 
 Returns a new `Heavy` object.
 
@@ -31,5 +32,6 @@ When `sampleInterval` is `0`, this operation does nothing.
 Object with the current process load:
 
 - `eventLoopDelay` - current event loop delay milliseconds.
+- `eventLoopUtilization` - current event loop utilization value.
 - `heapUsed` - current V8 heap size bytes.
 - `rss` - current process RSS size bytes.

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,6 +98,7 @@ internals.Heavy.prototype.check = function () {
 
     if (elapsed > this.settings.sampleInterval) {
         load.eventLoopDelay = Math.max(load.eventLoopDelay, elapsed - this.settings.sampleInterval);
+        load.eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization).utilization;
     }
 
     if (this.settings.maxEventLoopDelay &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const PerfHooks = require('perf_hooks');
 const Boom = require('@hapi/boom');
 const Hoek = require('@hapi/hoek');
 const Validate = require('@hapi/validate');
@@ -12,6 +13,7 @@ internals.schema = Validate.object({
     sampleInterval: Validate.number().min(0),
     maxHeapUsedBytes: Validate.number().min(0),
     maxEventLoopDelay: Validate.number().min(0),
+    maxEventLoopUtilization: Validate.number().min(0),
     maxRssBytes: Validate.number().min(0)
 })
     .unknown();
@@ -21,7 +23,8 @@ internals.defaults = {
     sampleInterval: 0,                          // Frequency of load sampling in milliseconds (zero is no sampling)
     maxHeapUsedBytes: 0,                        // Reject requests when V8 heap is over size in bytes (zero is no max)
     maxRssBytes: 0,                             // Reject requests when process RSS is over size in bytes (zero is no max)
-    maxEventLoopDelay: 0                        // Milliseconds of delay after which requests are rejected (zero is no max)
+    maxEventLoopDelay: 0,                       // Milliseconds of delay after which requests are rejected (zero is no max)
+    maxEventLoopUtilization: 0                  // Max event loop utilization value after which requests are rejected (zero is no max)
 };
 
 
@@ -31,12 +34,14 @@ exports = module.exports = internals.Heavy = function (options) {
 
     Validate.assert(options, internals.schema, 'Invalid load monitoring options');
     this.settings = Hoek.applyToDefaults(internals.defaults, options);
-    Hoek.assert(this.settings.sampleInterval || (!this.settings.maxEventLoopDelay && !this.settings.maxHeapUsedBytes && !this.settings.maxRssBytes), 'Load sample interval must be set to enable load limits');
+    Hoek.assert(this.settings.sampleInterval || (!this.settings.maxEventLoopDelay && !this.settings.maxHeapUsedBytes && !this.settings.maxRssBytes && !this.settings.maxEventLoopUtilization), 'Load sample interval must be set to enable load limits');
 
     this._eventLoopTimer = null;
+    this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization();
     this._loadBench = new Hoek.Bench();
     this.load = {
         eventLoopDelay: 0,
+        eventLoopUtilization: 0,
         heapUsed: 0,
         rss: 0
     };
@@ -59,6 +64,7 @@ internals.Heavy.prototype.start = function () {
             // Retain the same this.load object to keep external references valid
 
             this.load.eventLoopDelay = (this._loadBench.elapsed() - this.settings.sampleInterval);
+            this.load.eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization).utilization;
             this.load.heapUsed = mem.heapUsed;
             this.load.rss = mem.rss;
 
@@ -98,6 +104,12 @@ internals.Heavy.prototype.check = function () {
         load.eventLoopDelay > this.settings.maxEventLoopDelay) {
 
         throw Boom.serverUnavailable('Server under heavy load (event loop)', load);
+    }
+
+    if (this.settings.maxEventLoopUtilization &&
+        load.eventLoopUtilization > this.settings.maxEventLoopUtilization) {
+
+        throw Boom.serverUnavailable('Server under heavy load (event loop utilization)', load);
     }
 
     if (this.settings.maxHeapUsedBytes &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,8 +63,10 @@ internals.Heavy.prototype.start = function () {
 
             // Retain the same this.load object to keep external references valid
 
+            this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
+
             this.load.eventLoopDelay = (this._loadBench.elapsed() - this.settings.sampleInterval);
-            this.load.eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization).utilization;
+            this.load.eventLoopUtilization = this._eventLoopUtilization.utilization;
             this.load.heapUsed = mem.heapUsed;
             this.load.rss = mem.rss;
 
@@ -97,8 +99,10 @@ internals.Heavy.prototype.check = function () {
     const load = this.load;
 
     if (elapsed > this.settings.sampleInterval) {
+        this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
+
         load.eventLoopDelay = Math.max(load.eventLoopDelay, elapsed - this.settings.sampleInterval);
-        load.eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization).utilization;
+        load.eventLoopUtilization = this._eventLoopUtilization.utilization;
     }
 
     if (this.settings.maxEventLoopDelay &&

--- a/test/index.js
+++ b/test/index.js
@@ -130,7 +130,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopUtilization).to.equal(0);
 
         await Hoek.wait(0);
-        sleep(50);
+        sleep(500);
 
         expect(() => heavy.check()).to.throw('Server under heavy load (event loop utilization)');
         expect(heavy.load.eventLoopUtilization).to.be.above(0);

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopDelay).to.be.above(0);
 
         await Hoek.wait(0);
-        sleep(500);
+        sleep(5);
 
         expect(heavy.load.eventLoopDelay).to.be.above(0);
         expect(heavy.load.eventLoopUtilization).to.be.above(0);
@@ -130,7 +130,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopUtilization).to.equal(0);
 
         await Hoek.wait(0);
-        sleep(5);
+        sleep(50);
 
         expect(() => heavy.check()).to.throw('Server under heavy load (event loop utilization)');
         expect(heavy.load.eventLoopUtilization).to.be.above(0);

--- a/test/index.js
+++ b/test/index.js
@@ -130,7 +130,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopUtilization).to.equal(0);
 
         await Hoek.wait(0);
-        sleep(500);
+        sleep(5);
 
         expect(() => heavy.check()).to.throw('Server under heavy load (event loop utilization)');
         expect(heavy.load.eventLoopUtilization).to.be.above(0);

--- a/test/index.js
+++ b/test/index.js
@@ -122,7 +122,7 @@ describe('Heavy', () => {
 
     it('fails check due to high event loop utilization value', async () => {
 
-        const heavy = new Heavy({ sampleInterval: 1, maxEventLoopUtilization: 0.3 });
+        const heavy = new Heavy({ sampleInterval: 1, maxEventLoopUtilization: 0.1 });
 
         heavy.start();
 

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopDelay).to.be.above(0);
 
         await Hoek.wait(0);
-        sleep(5);
+        sleep(50);
 
         expect(heavy.load.eventLoopDelay).to.be.above(0);
         expect(heavy.load.eventLoopUtilization).to.be.above(0);

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ describe('Heavy', () => {
         expect(heavy.load.eventLoopDelay).to.be.above(0);
 
         await Hoek.wait(0);
-        sleep(50);
+        sleep(500);
 
         expect(heavy.load.eventLoopDelay).to.be.above(0);
         expect(heavy.load.eventLoopUtilization).to.be.above(0);

--- a/test/index.js
+++ b/test/index.js
@@ -17,17 +17,22 @@ describe('Heavy', () => {
 
     it('requires load interval when maxEventLoopDelay is set', () => {
 
-        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 10, maxHeapUsedBytes: 0, maxRssBytes: 0 })).to.throw('Load sample interval must be set to enable load limits');
+        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 10, maxEventLoopUtilization: 0, maxHeapUsedBytes: 0, maxRssBytes: 0 })).to.throw('Load sample interval must be set to enable load limits');
+    });
+
+    it('requires load interval when maxEventLoopUtilization is set', () => {
+
+        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 0, maxEventLoopUtilization: 10, maxHeapUsedBytes: 0, maxRssBytes: 0 })).to.throw('Load sample interval must be set to enable load limits');
     });
 
     it('requires load interval when maxHeapUsedBytes is set', () => {
 
-        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 0, maxHeapUsedBytes: 10, maxRssBytes: 0 })).to.throw('Load sample interval must be set to enable load limits');
+        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 0, maxEventLoopUtilization: 0, maxHeapUsedBytes: 10, maxRssBytes: 0 })).to.throw('Load sample interval must be set to enable load limits');
     });
 
     it('requires load interval when maxRssBytes is set', () => {
 
-        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 0, maxHeapUsedBytes: 0, maxRssBytes: 10 })).to.throw('Load sample interval must be set to enable load limits');
+        expect(() => new Heavy({ sampleInterval: 0, maxEventLoopDelay: 0, maxEventLoopUtilization: 0, maxHeapUsedBytes: 0, maxRssBytes: 10 })).to.throw('Load sample interval must be set to enable load limits');
     });
 
     const sleep = function (msec) {
@@ -51,6 +56,7 @@ describe('Heavy', () => {
         sleep(5);
 
         expect(heavy.load.eventLoopDelay).to.be.above(0);
+        expect(heavy.load.eventLoopUtilization).to.be.above(0);
         expect(heavy.load.heapUsed).to.be.above(1024 * 1024);
         expect(heavy.load.rss).to.be.above(1024 * 1024);
         heavy.stop();
@@ -111,6 +117,23 @@ describe('Heavy', () => {
 
         expect(() => heavy.check()).to.throw('Server under heavy load (event loop)');
         expect(heavy.load.eventLoopDelay).to.be.above(0);
+        heavy.stop();
+    });
+
+    it('fails check due to high event loop utilization value', async () => {
+
+        const heavy = new Heavy({ sampleInterval: 1, maxEventLoopUtilization: 0.3 });
+
+        heavy.start();
+
+        expect(() => heavy.check()).to.not.throw();
+        expect(heavy.load.eventLoopUtilization).to.equal(0);
+
+        await Hoek.wait(0);
+        sleep(5);
+
+        expect(() => heavy.check()).to.throw('Server under heavy load (event loop utilization)');
+        expect(heavy.load.eventLoopUtilization).to.be.above(0);
         heavy.stop();
     });
 


### PR DESCRIPTION
Introduces support to track the [event loop utilization](https://nodejs.org/dist/latest-v12.x/docs/api/perf_hooks.html#perf_hooks_performance_eventlooputilization_utilization1_utilization2), the intent is to add this support to hapi itself as described at https://github.com/hapijs/hapi/issues/4288

**Notes:**
- `performance.eventLoopUtilization` is available from Node 12.19.0. Not certain if introducing this support would be a breaking change or not.

