### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2013-2020, Sideway Inc, and project contributors  
-Copyright (c) 2013-2014, Walmart.  
+Copyright (c) 2013-2022, Project contributors
+Copyright (c) 2013-2020, Sideway Inc
+Copyright (c) 2013-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,104 +28,104 @@ internals.defaults = {
 };
 
 
-exports = module.exports = internals.Heavy = function (options) {
+exports.Heavy = class Heavy {
 
-    options = options || {};
+    constructor(options) {
 
-    Validate.assert(options, internals.schema, 'Invalid load monitoring options');
-    this.settings = Hoek.applyToDefaults(internals.defaults, options);
-    Hoek.assert(this.settings.sampleInterval || (!this.settings.maxEventLoopDelay && !this.settings.maxHeapUsedBytes && !this.settings.maxRssBytes && !this.settings.maxEventLoopUtilization), 'Load sample interval must be set to enable load limits');
+        options = options || {};
 
-    this._eventLoopTimer = null;
-    this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization();
-    this._loadBench = new Hoek.Bench();
-    this.load = {
-        eventLoopDelay: 0,
-        eventLoopUtilization: 0,
-        heapUsed: 0,
-        rss: 0
-    };
-};
+        Validate.assert(options, internals.schema, 'Invalid load monitoring options');
+        this.settings = Hoek.applyToDefaults(internals.defaults, options);
+        Hoek.assert(this.settings.sampleInterval || (!this.settings.maxEventLoopDelay && !this.settings.maxHeapUsedBytes && !this.settings.maxRssBytes && !this.settings.maxEventLoopUtilization), 'Load sample interval must be set to enable load limits');
 
-
-internals.Heavy.prototype.start = function () {
-
-    if (!this.settings.sampleInterval) {
-        return;
+        this._eventLoopTimer = null;
+        this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization();
+        this._loadBench = new Hoek.Bench();
+        this.load = {
+            eventLoopDelay: 0,
+            eventLoopUtilization: 0,
+            heapUsed: 0,
+            rss: 0
+        };
     }
 
-    const loopSample = () => {
+    start() {
 
-        this._loadBench.reset();
-        const measure = () => {
+        if (!this.settings.sampleInterval) {
+            return;
+        }
 
-            const mem = process.memoryUsage();
+        const loopSample = () => {
 
-            // Retain the same this.load object to keep external references valid
+            this._loadBench.reset();
+            const measure = () => {
 
-            this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
+                const mem = process.memoryUsage();
 
-            this.load.eventLoopDelay = (this._loadBench.elapsed() - this.settings.sampleInterval);
-            this.load.eventLoopUtilization = this._eventLoopUtilization.utilization;
-            this.load.heapUsed = mem.heapUsed;
-            this.load.rss = mem.rss;
+                // Retain the same this.load object to keep external references valid
 
-            loopSample();
+                this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
+
+                this.load.eventLoopDelay = (this._loadBench.elapsed() - this.settings.sampleInterval);
+                this.load.eventLoopUtilization = this._eventLoopUtilization.utilization;
+                this.load.heapUsed = mem.heapUsed;
+                this.load.rss = mem.rss;
+
+                loopSample();
+            };
+
+            this._eventLoopTimer = setTimeout(measure, this.settings.sampleInterval);
         };
 
-        this._eventLoopTimer = setTimeout(measure, this.settings.sampleInterval);
-    };
-
-    loopSample();
-};
-
-
-internals.Heavy.prototype.stop = function () {
-
-    clearTimeout(this._eventLoopTimer);
-    this._eventLoopTimer = null;
-};
-
-
-internals.Heavy.prototype.check = function () {
-
-    if (!this.settings.sampleInterval) {
-        return;
+        loopSample();
     }
 
-    Hoek.assert(this._eventLoopTimer, 'Cannot check load when sampler is not started');
+    stop() {
 
-    const elapsed = this._loadBench.elapsed();
-    const load = this.load;
-
-    if (elapsed > this.settings.sampleInterval) {
-        this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
-
-        load.eventLoopDelay = Math.max(load.eventLoopDelay, elapsed - this.settings.sampleInterval);
-        load.eventLoopUtilization = this._eventLoopUtilization.utilization;
+        clearTimeout(this._eventLoopTimer);
+        this._eventLoopTimer = null;
     }
 
-    if (this.settings.maxEventLoopDelay &&
-        load.eventLoopDelay > this.settings.maxEventLoopDelay) {
+    check() {
 
-        throw Boom.serverUnavailable('Server under heavy load (event loop)', load);
-    }
+        if (!this.settings.sampleInterval) {
+            return;
+        }
 
-    if (this.settings.maxEventLoopUtilization &&
-        load.eventLoopUtilization > this.settings.maxEventLoopUtilization) {
+        Hoek.assert(this._eventLoopTimer, 'Cannot check load when sampler is not started');
 
-        throw Boom.serverUnavailable('Server under heavy load (event loop utilization)', load);
-    }
+        const elapsed = this._loadBench.elapsed();
+        const load = this.load;
 
-    if (this.settings.maxHeapUsedBytes &&
-        load.heapUsed > this.settings.maxHeapUsedBytes) {
+        if (elapsed > this.settings.sampleInterval) {
+            this._eventLoopUtilization = PerfHooks.performance.eventLoopUtilization(this._eventLoopUtilization);
 
-        throw Boom.serverUnavailable('Server under heavy load (heap)', load);
-    }
+            load.eventLoopDelay = Math.max(load.eventLoopDelay, elapsed - this.settings.sampleInterval);
+            load.eventLoopUtilization = this._eventLoopUtilization.utilization;
+        }
 
-    if (this.settings.maxRssBytes &&
-        load.rss > this.settings.maxRssBytes) {
+        if (this.settings.maxEventLoopDelay &&
+            load.eventLoopDelay > this.settings.maxEventLoopDelay) {
 
-        throw Boom.serverUnavailable('Server under heavy load (rss)', load);
+            throw Boom.serverUnavailable('Server under heavy load (event loop)', load);
+        }
+
+        if (this.settings.maxEventLoopUtilization &&
+            load.eventLoopUtilization > this.settings.maxEventLoopUtilization) {
+
+            throw Boom.serverUnavailable('Server under heavy load (event loop utilization)', load);
+        }
+
+        if (this.settings.maxHeapUsedBytes &&
+            load.heapUsed > this.settings.maxHeapUsedBytes) {
+
+            throw Boom.serverUnavailable('Server under heavy load (heap)', load);
+        }
+
+        if (this.settings.maxRssBytes &&
+            load.rss > this.settings.maxRssBytes) {
+
+            throw Boom.serverUnavailable('Server under heavy load (rss)', load);
+        }
     }
 };

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Heavy;
+
+    before(async () => {
+
+        Heavy = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Heavy)).to.equal([
+            'Heavy',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Code = require('@hapi/code');
-const Heavy = require('..');
+const { Heavy } = require('..');
 const Hoek = require('@hapi/hoek');
 const Lab = require('@hapi/lab');
 


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.
 - Made Heavy an ES6 class— I recommend reviewing with whitespace ignored.
 - Changed export to `exports.Heavy` rather than `module.exports` for more standard ESM usage.

If this looks good, this will go out as heavy v8.